### PR TITLE
Refactor: Optimize and fix sortHierarchicalMenu

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,93 @@
+## Analysis of `sortHierarchicalMenu` Function in `src/lib/helpers.js`
+
+Date: 2024-07-30
+
+### Function Purpose
+
+The `sortHierarchicalMenu` function is designed to sort menu items based on a predefined hierarchical order. This order is specified in an array named `menu` within the function. The sorting is case-insensitive.
+
+### Current Sorting Logic
+
+1.  Both item names (`a.name`, `b.name`) are converted to lowercase.
+2.  If `a.name` is present in the `menu` array:
+    a.  Its index (`aLocation`) is retrieved.
+    b.  If `b.name` is also present in the `menu` array at or after `aLocation`, `a` is sorted before `b` (returns `-1`).
+    c.  Otherwise (if `b.name` is not in `menu` or is in `menu` but before `a.name`), `a` is sorted after `b` (returns `1`).
+3.  If `a.name` is NOT present in the `menu` array:
+    a.  `a` is sorted before `b` (returns `-1`), regardless of whether `b.name` is in the `menu` or not.
+
+### Findings
+
+#### 1. Determination of Bug vs. Specific Purpose
+
+The current sorting logic appears to contain **bugs** regarding the handling of items not present in the predefined `menu` array, and also in how it relatively orders known vs. unknown items.
+
+*   **Intended Purpose:** The primary goal is clearly to order items according to the `menu` array.
+*   **Observed Behavior Contrary to Typical Expectations:**
+    *   Items *not* in the `menu` list are consistently sorted *before* items that *are* in the `menu` list if the comparison order happens to place the "unknown" item as `a` in the comparator, or if `a` is known and `b` is unknown.
+    *   Example: If `menu = ["tora", "talmud"]`:
+        *   `sortHierarchicalMenu({name: "tora"}, {name: "zebra"})` would result in `["zebra", "tora"]` (because `a` is "tora", `b` is "zebra"; `menu.includes("zebra", indexOf("tora"))` is false, returns `1`, sorting `a` after `b`). This is incorrect; "tora" should come first.
+        *   `sortHierarchicalMenu({name: "zebra"}, {name: "tora"})` would result in `["zebra", "tora"]` (because `a` is "zebra"; `menu.includes("zebra")` is false, returns `-1`, sorting `a` before `b`). This is also incorrect.
+
+#### 2. Potential Edge Cases & Incorrect/Inefficient Sorting
+
+*   **Edge Case 1: Item `a` in `menu`, Item `b` NOT in `menu`**
+    *   Current: `b` is sorted before `a`.
+    *   Example: `a = {name: "tora"}, b = {name: "unknown"}` -> sorts to `[unknown, tora]`.
+    *   Expected: `a` should be sorted before `b`. `[tora, unknown]`.
+
+*   **Edge Case 2: Item `a` NOT in `menu`, Item `b` in `menu`**
+    *   Current: `a` is sorted before `b`.
+    *   Example: `a = {name: "unknown"}, b = {name: "tora"}` -> sorts to `[unknown, tora]`.
+    *   Expected: `b` should be sorted before `a`. `[tora, unknown]`.
+
+*   **Edge Case 3: Neither Item `a` nor Item `b` are in `menu`**
+    *   Current: `a` is always sorted before `b`. If the input array had `[{name:"zebra"}, {name:"apple"}]`, they would sort as `["zebra", "apple"]`. If `[{name:"apple"}, {name:"zebra"}]`, then `["apple", "zebra"]`. Their relative order depends on their original positions when `a` is not in `menu`.
+    *   Expected: Items not in the `menu` array should ideally be sorted by a secondary criterion, typically alphabetically. E.g., `apple` before `zebra`.
+
+*   **Edge Case 4: Identical items or items with same name**
+    *   If `a.name` and `b.name` are identical, and present in `menu`:
+        *   `aLocation = menu.indexOf(aValue)`
+        *   `menu.includes(bValue, aLocation)` will be true.
+        *   Returns `-1`. This maintains stability for identical items if `a` was already before `b`.
+    *   If `a.name` and `b.name` are identical, and NOT present in `menu`:
+        *   Returns `-1`. This also maintains stability.
+    *   This part seems fine.
+
+*   **Inefficiency:**
+    *   The `menu.includes()` and `menu.indexOf()` methods are called repeatedly within the sort comparator. For a large number of items to sort or a very long `menu` array, this could lead to performance degradation. A more optimal approach would be to create a lookup map (e.g., `{"tora": 0, "ketubim": 1, ...}`) once, outside the comparator, and use this map for quick index retrieval.
+
+### Recommended Changes for Correctness
+
+1.  **Prioritize known items:** Items whose names are in the `menu` array should always come before items not in the `menu` array.
+2.  **Sort known items by `menu` order:** If both items are in `menu`, their order should be determined by their respective indices in `menu`.
+3.  **Sort unknown items alphabetically:** If both items are not in `menu`, they should be sorted alphabetically by name.
+4.  **Optimize lookups:** For better performance, convert the `menu` array into an object/Map for O(1) average time complexity lookups of item indices.
+
+### Example of Flawed Logic:
+
+Given `menu = ["tora", "talmud", "misc"]` and items:
+*   `item1 = {name: "talmud"}`
+*   `item2 = {name: "otherbooks"}` (not in `menu`)
+*   `item3 = {name: "tora"}`
+
+Sorting `[item1, item2, item3]` (i.e. `["talmud", "otherbooks", "tora"]`)
+
+1.  Compare `"talmud"` and `"otherbooks"`:
+    *   `a="talmud"`, `b="otherbooks"`
+    *   `a` is in `menu`. `aLocation = 1`.
+    *   `b` is not in `menu` starting from `aLocation`.
+    *   Returns `1`. Sorts `talmud` after `otherbooks`. Array becomes `["otherbooks", "talmud", "tora"]` (conceptually during sort). This is wrong.
+
+2.  Compare `"otherbooks"` and `"tora"` (if sort algorithm proceeds this way):
+    *   `a="otherbooks"`, `b="tora"`
+    *   `a` is not in `menu`.
+    *   Returns `-1`. Sorts `otherbooks` before `tora`. Array might be `["otherbooks", "tora", "talmud"]`. This is also wrong.
+
+The final sorted order with the current logic would likely be incorrect, with "otherbooks" potentially appearing before "tora" and "talmud".
+
+The desired order is `["tora", "talmud", "otherbooks"]`.
+
+### Conclusion
+
+The current sorting logic has significant flaws in how it handles items not explicitly listed in the `menu` array, leading to incorrect sorting outcomes where unlisted items can be prioritized over listed ones, or listed items are sorted incorrectly against unlisted ones. It needs to be revised to handle these cases logically, likely by ensuring all items in the `menu` list come first (sorted by that list), followed by other items (sorted alphabetically). The performance aspect is a minor concern but could be improved.

--- a/SORTING_REPORT.md
+++ b/SORTING_REPORT.md
@@ -1,0 +1,45 @@
+# Sorting Logic Analysis Report: `sortHierarchicalMenu`
+
+**Date:** 2024-07-30
+**Source File:** `src/lib/helpers.js`
+**Analyzed Content:** `ANALYSIS.md`
+
+## 1. Introduction
+
+This report summarizes the analysis of the `sortHierarchicalMenu` JavaScript function. The function's intended purpose is to sort menu items according to a predefined hierarchical order specified within an internal `menu` array, performing a case-insensitive comparison.
+
+## 2. Key Issue: Flawed Handling of Unlisted Menu Items
+
+The primary issue identified is that the current sorting logic **incorrectly handles menu items not present in its predefined `menu` list** and also errs in comparisons between listed and unlisted items.
+
+*   **Incorrect Prioritization:** The logic can cause items *not* on the predefined `menu` list to be sorted *before* items that *are* on the list.
+    *   For example, if `a` (e.g., "tora", which is in `menu`) is compared with `b` (e.g., "zebra", not in `menu`), the function sorts `b` before `a`.
+    *   Similarly, if `a` (e.g., "zebra", not in `menu`) is compared with `b` (e.g., "tora", in `menu`), the function sorts `a` before `b`.
+*   This behavior contradicts the expected outcome where items explicitly defined in the sort order (`menu` array) should take precedence.
+
+## 3. Potential Impact
+
+The flawed sorting logic can lead to several negative impacts:
+
+*   **Incorrect Menu Display:** Hierarchical menus may not display in the intended order. For instance, critical or foundational menu items (like "Tora", "Talmud") might appear after miscellaneous or uncategorized items.
+*   **User Confusion:** Inconsistent or illogical menu ordering can confuse users navigating the site, making it harder to find information.
+*   **Maintenance Difficulties:** The non-intuitive sorting rules make the code harder to understand and maintain. Adding new items to the menu might have unpredictable results on their final sorted position if not also added to the hardcoded `menu` array.
+
+## 4. Secondary Issues and Edge Cases
+
+Beyond the primary bug, the analysis also noted:
+
+*   **No Fallback Sorting for Unlisted Items:** When comparing two items that are *both not* in the `menu` array, their relative order is based on their original positions in the input array rather than a logical fallback (e.g., alphabetical sorting).
+*   **Minor Inefficiency:** The function repeatedly uses `menu.includes()` and `menu.indexOf()` within the sort comparator, which can be inefficient for large menus or many items. This is a minor concern compared to the logical flaws.
+
+## 5. Conclusion from `ANALYSIS.md`
+
+"The current sorting logic has significant flaws in how it handles items not explicitly listed in the `menu` array, leading to incorrect sorting outcomes where unlisted items can be prioritized over listed ones, or listed items are sorted incorrectly against unlisted ones. It needs to be revised to handle these cases logically, likely by ensuring all items in the `menu` list come first (sorted by that list), followed by other items (sorted alphabetically). The performance aspect is a minor concern but could be improved."
+
+## 6. Recommendation
+
+It is highly recommended to refactor the `sortHierarchicalMenu` function to:
+1.  Correctly prioritize items present in the `menu` array over those not present.
+2.  Sort items present in the `menu` array according to their defined order.
+3.  Implement a secondary sorting mechanism (e.g., alphabetical) for items not found in the `menu` array.
+4.  Consider optimizing array lookups for improved performance (e.g., by using a Map).

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -32,20 +32,47 @@ export function buildImageObj(source) {
   return imageObj;
 }
 
+// Define the menu order and create a lookup map for efficient sorting.
+// This is done once when the module is loaded, not on every sort comparison.
+const PREDEFINED_MENU_ORDER = [
+  "tora", "ketubim", "nebi'im", "talmud", "harambam", "tefilla",
+  "personalities", "law", "holidays", "hebrew grammar / diqduq",
+  "jewish history", "jewish thought", "yehuda halevi / kuzari",
+  "matte dan", "sephardic history", "misc", "other"
+];
+
+const menuOrderLookup = PREDEFINED_MENU_ORDER.reduce((acc, item, index) => {
+  acc[item] = index;
+  return acc;
+}, {});
+
 export const sortHierarchicalMenu = (a, b) => {
+  const aName = a.name ? a.name.toLocaleLowerCase() : "";
+  const bName = b.name ? b.name.toLocaleLowerCase() : "";
 
-  var aValue = a.name.toLocaleLowerCase()
-  var bValue = b.name.toLocaleLowerCase()
+  const aIndex = menuOrderLookup[aName];
+  const bIndex = menuOrderLookup[bName];
 
-  var menu = ["tora", "ketubim", "nebi'im", "talmud", "harambam", "tefilla", "personalities", "law", 
-              "holidays", "hebrew grammar / diqduq", "jewish history", "jewish thought", "yehuda halevi / kuzari",
-             "matte dan", "sephardic history", "misc", "other"]
-  if (menu.includes(aValue)) {
-    var aLocation = menu.indexOf(aValue)
-    return (menu.includes(bValue, aLocation)) ? -1 : 1
+  const aIsInMenu = aIndex !== undefined;
+  const bIsInMenu = bIndex !== undefined;
+
+  if (aIsInMenu && bIsInMenu) {
+    // Both items are in the predefined menu order. Sort by their index.
+    return aIndex - bIndex;
+  } else if (aIsInMenu) {
+    // Item 'a' is in the menu, item 'b' is not. 'a' comes first.
+    return -1;
+  } else if (bIsInMenu) {
+    // Item 'b' is in the menu, item 'a' is not. 'b' comes first.
+    return 1;
+  } else {
+    // Neither item is in the predefined menu. Sort them alphabetically.
+    if (aName < bName) {
+      return -1;
+    }
+    if (aName > bName) {
+      return 1;
+    }
+    return 0;
   }
-
-// 1 sort a after b, e.g. [b, a]
-// -1 sort a before b, e.g. [a, b]
-  return  -1;
 };

--- a/tests/lib/helpers.test.js
+++ b/tests/lib/helpers.test.js
@@ -1,0 +1,136 @@
+import { sortHierarchicalMenu } from '../../src/lib/helpers';
+
+describe('sortHierarchicalMenu', () => {
+  const tora = { name: 'Tora' };
+  const ketubim = { name: 'Ketubim' };
+  const nebiim = { name: "Nebi'im" };
+  const talmud = { name: 'Talmud' };
+  const harambam = { name: 'Harambam' };
+  const misc = { name: 'Misc' };
+  const other = { name: 'Other' };
+
+  // Items not in the predefined list
+  const apple = { name: 'Apple' };
+  const zebra = { name: 'Zebra' };
+  const banana = { name: 'Banana' };
+  const unknown = { name: 'Unknown Category' };
+
+  // Predefined order for reference (lowercase):
+  // "tora", "ketubim", "nebi'im", "talmud", "harambam", ..., "misc", "other"
+
+  it('should sort items all present in the predefined menu correctly', () => {
+    const items = [talmud, tora, harambam, nebiim, ketubim];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([tora, ketubim, nebiim, talmud, harambam]);
+  });
+
+  it('should handle items with different casing correctly (case-insensitive)', () => {
+    const items = [{ name: 'TALMUD' }, { name: 'tora' }, { name: 'harambam' }];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([{ name: 'tora' }, { name: 'TALMUD' }, { name: 'harambam' }]);
+  });
+
+  it('should sort items not in the predefined menu alphabetically', () => {
+    const items = [zebra, apple, unknown, banana];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([apple, banana, unknown, zebra]);
+  });
+
+  it('should sort mixed items: predefined first, then alphabetical for others', () => {
+    const items = [banana, talmud, apple, tora, zebra, harambam, unknown];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([
+      tora,       // Predefined
+      talmud,     // Predefined
+      harambam,   // Predefined
+      apple,      // Alphabetical
+      banana,     // Alphabetical
+      unknown,    // Alphabetical
+      zebra       // Alphabetical
+    ]);
+  });
+
+  it('should place predefined items before non-predefined items', () => {
+    const items = [apple, tora];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([tora, apple]);
+
+    const items2 = [tora, apple];
+    items2.sort(sortHierarchicalMenu);
+    expect(items2).toEqual([tora, apple]);
+  });
+
+  it('should correctly sort "misc" and "other" according to their defined order', () => {
+    const items = [other, misc, tora];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([tora, misc, other]);
+
+    const items2 = [misc, other];
+    items2.sort(sortHierarchicalMenu);
+    expect(items2).toEqual([misc, other]);
+  });
+
+  it('should handle an empty array input (sort does nothing)', () => {
+    const items = [];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([]);
+  });
+
+  it('should handle items with identical names (stability check)', () => {
+    const tora1 = { name: 'Tora', id: 1 };
+    const tora2 = { name: 'Tora', id: 2 };
+    const apple1 = { name: 'Apple', id: 1 };
+    const apple2 = { name: 'Apple', id: 2 };
+
+    // Test with items in predefined list
+    let items = [tora2, tora1];
+    items.sort(sortHierarchicalMenu);
+    // JavaScript's sort is not guaranteed stable by default, but for items
+    // that compare as equal (0), their order should be preserved.
+    // Our function returns 0 for identical predefined items (aIndex - bIndex will be 0).
+    expect(items).toEqual([tora2, tora1]);
+
+    items = [tora1, tora2];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([tora1, tora2]);
+
+    // Test with items not in predefined list
+    items = [apple2, apple1];
+    items.sort(sortHierarchicalMenu);
+    // Our function returns 0 for identical non-predefined items.
+    expect(items).toEqual([apple2, apple1]);
+
+    items = [apple1, apple2];
+    items.sort(sortHierarchicalMenu);
+    expect(items).toEqual([apple1, apple2]);
+  });
+
+  it('should handle items with missing or null name properties (treated as empty strings)', () => {
+    const itemWithNullName = { name: null, id: 1 };
+    const itemWithMissingName = { id: 2 }; // name is undefined
+    const itemWithEmptyName = { name: "", id: 3 };
+
+    // All non-predefined, should sort alphabetically (empty strings first)
+    // and then by stability or original order for equal ones.
+    // "" vs "" is 0.
+    // "" vs "apple" is -1.
+    const items = [apple, itemWithNullName, itemWithMissingName, itemWithEmptyName];
+    items.sort(sortHierarchicalMenu);
+
+    // Expected: empty/null/undefined names first (as they become ""), then 'apple'.
+    // The relative order of items that all convert to "" for name is preserved.
+    expect(items).toEqual([itemWithNullName, itemWithMissingName, itemWithEmptyName, apple]);
+
+    const items2 = [itemWithEmptyName, itemWithMissingName, apple, itemWithNullName];
+    items2.sort(sortHierarchicalMenu);
+    expect(items2).toEqual([itemWithEmptyName, itemWithMissingName, itemWithNullName, apple]);
+  });
+
+  it('should handle a mix of predefined, non-predefined, and "emptyish" named items', () => {
+    const itemWithNullName = { name: null, id: 1 }; // Becomes ""
+    const items = [misc, apple, itemWithNullName, tora];
+    items.sort(sortHierarchicalMenu);
+    // Expected: tora, misc (predefined), then "" (from null), then apple
+    expect(items).toEqual([tora, misc, itemWithNullName, apple]);
+  });
+});


### PR DESCRIPTION
The `sortHierarchicalMenu` function in `src/lib/helpers.js` had suboptimal logic for sorting items, especially those not present in its predefined `menu` array. This could lead to incorrect sorting orders in hierarchical menus.

This commit refactors the function to:
- Prioritize items listed in the predefined `menu`.
- Sort items within the predefined `menu` according to their specified order.
- Sort items not in the predefined `menu` alphabetically as a fallback.
- Improve performance by using a Map for O(1) average time complexity lookups of predefined menu item order.
- Handle case insensitivity for item names.

New unit tests have been added in `tests/lib/helpers.test.js` to cover various scenarios and ensure the correctness of the new sorting logic.